### PR TITLE
Fix README to import correct file

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ See official documentation [here](https://github.com/drewjbartlett/simple-breakp
 
 ```javascript
     import Vue from 'vue'
-    import SimpleBreakpoints from 'simple-breakpoints'
+    import VueSimpleBreakpoints from 'vue-simple-breakpoints'
 
-    Vue.use(SimpleBreakpoints)
+    Vue.use(VueSimpleBreakpoints)
 
     new Vue({
         el: '#app',
@@ -41,9 +41,9 @@ See official documentation [here](https://github.com/drewjbartlett/simple-breakp
 
 ```javascript
     import Vue from 'vue'
-    import SimpleBreakpoints from 'simple-breakpoints'
+    import VueSimpleBreakpoints from 'vue-simple-breakpoints'
 
-    Vue.use(SimpleBreakpoints, { mobile: 320, tablet: 640, small_desktop: 1000, large_desktop: 1200 })
+    Vue.use(VueSimpleBreakpoints, { mobile: 320, tablet: 640, small_desktop: 1000, large_desktop: 1200 })
 
     new Vue({
         el: '#app',


### PR DESCRIPTION
The README file currently instructs users to import `simple-breakpoints` when we actually want to be importing `vue-simple-breakpoints`.

Also note that the `tablet` variable isn't utilised correctly in the `simple-breakpoints` repo. `isMobile()` checks below `mobile`, but `isTablet()` checks between `mobile` and `small_desktop`, when it should be between `mobile` and `tablet` to be consistent there. The tablet variable is totally ignored in calculating which breakpoint we're on. Haven't submitted a PR for that as I'm not sure if it'll break any backwards compatibility?

Thanks for your work on this, it's been a great base for me to get breakpoints working in Vue, just needed to fix the issue in README, the tablet issue and then tweak to my needs a little (in my use case I'm returning bootstrap style breakpoints (`default`, `xs`, `sm`, `md`, `lg`)).